### PR TITLE
Adding uuid7

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 * [ulauncher](https://ulauncher.io/)
 * Python >= 2.7
-* uuid (`pip install uuid`)
+* uuid (`pip install uuid`) and (`pip install uuid7`)
 
 ## Install
 

--- a/main.py
+++ b/main.py
@@ -1,5 +1,6 @@
 import logging
 import uuid
+from uuid_extensions import uuid7str
 from ulauncher.api.client.Extension import Extension
 from ulauncher.api.client.EventListener import EventListener
 from ulauncher.api.shared.event import KeywordQueryEvent
@@ -23,7 +24,7 @@ class KeywordQueryEventListener(EventListener):
     def on_event(self, event, extension):
         items = []
         generated_uuids = []
-        accepted_versions = ["v1", "v3", "v4", "v5"]
+        accepted_versions = ["v1", "v3", "v4", "v5", "v7"]
         args = None
         v = "v4"
         name = "python.org"
@@ -55,6 +56,8 @@ class KeywordQueryEventListener(EventListener):
         elif v == "v5":
             generated_uuids.append(["UUID v5 DNS", str(uuid.uuid5(uuid.NAMESPACE_DNS, name))])
             generated_uuids.append(["UUID v5 URL", str(uuid.uuid5(uuid.NAMESPACE_URL, name))])
+        elif v == "v7":
+            generated_uuids.append(["UUID v7", uuid7str()])
 
         for desc, uuid_value in generated_uuids:
             items.append(ExtensionResultItem(icon='images/icon.png',


### PR DESCRIPTION
## What

Adding uuid7

## Why

Industry is moving to it because you can sort it by time which makes it ideal for database.

## How

Using [uuid7](https://pypi.org/project/uuid7/) package.

Unfortunately it does not support namespace and name prams.